### PR TITLE
Resolve post filter exception

### DIFF
--- a/Model/Posts/FilterArgument.php
+++ b/Model/Posts/FilterArgument.php
@@ -39,6 +39,6 @@ class FilterArgument implements FieldEntityAttributesInterface
         foreach ($this->config->getConfigElement('BlogPost')->getFields() as $field) {
             $fields[$field->getName()] = 'String';
         }
-        return array_keys($fields);
+        return $fields;
     }
 }


### PR DESCRIPTION
```
query {
    blogPosts(filter: {category_id: {eq: "1"}}) {
        items {
            post_id
        }
    }
}
```
```
{
"errors": [
{
"message": "Internal server error",
"extensions": {
"category": "internal"
},
```

[main] Attribute not found in the visible attributes list