### PR TITLE
Fixed: cannot handle widgets properly

### DIFF
--- a/Model/Resolver/DataProvider/Author.php
+++ b/Model/Resolver/DataProvider/Author.php
@@ -28,6 +28,11 @@ class Author
     private $authorRepository;
 
     /**
+     * @var Magento\Framework\App\State
+     */
+    protected $state;
+
+    /**
      * Author constructor.
      * @param AuthorRepositoryInterface $authorRepository
      * @param FilterEmulate $widgetFilter

--- a/Model/Resolver/DataProvider/Author.php
+++ b/Model/Resolver/DataProvider/Author.php
@@ -3,12 +3,12 @@
  * Copyright © Magefan (support@magefan.com). All rights reserved.
  * Please visit Magefan.com for license details (https://magefan.com/end-user-license-agreement).
  */
-declare(strict_types=1);
+declare (strict_types = 1);
 
 namespace Magefan\BlogGraphQl\Model\Resolver\DataProvider;
 
 use Magefan\Blog\Api\AuthorRepositoryInterface;
-use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\App\State;
 use Magento\Widget\Model\Template\FilterEmulate;
 
 /**
@@ -34,10 +34,12 @@ class Author
      */
     public function __construct(
         AuthorRepositoryInterface $authorRepository,
-        FilterEmulate $widgetFilter
+        FilterEmulate $widgetFilter,
+        State $state
     ) {
         $this->authorRepository = $authorRepository;
-        $this->widgetFilter = $widgetFilter;
+        $this->widgetFilter     = $widgetFilter;
+        $this->state            = $state;
     }
 
     /**
@@ -49,6 +51,16 @@ class Author
         $author = $this->authorRepository->getFactory()->create();
         $author->getResource()->load($author, $authorId);
 
-        return $author->getDynamicData();
+        $data = [];
+        $this->state->emulateAreaCode(
+            'frontend',
+            function () use ($author, &$data) {
+                $data = $author->getDynamicData();
+
+                return $data;
+            }
+        );
+
+        return $data;
     }
 }

--- a/Model/Resolver/DataProvider/Category.php
+++ b/Model/Resolver/DataProvider/Category.php
@@ -29,6 +29,11 @@ class Category
     private $categoryRepository;
 
     /**
+     * @var Magento\Framework\App\State
+     */
+    protected $state;
+
+    /**
      * Category constructor.
      * @param CategoryRepositoryInterface $categoryRepository
      * @param FilterEmulate $widgetFilter

--- a/Model/Resolver/DataProvider/Category.php
+++ b/Model/Resolver/DataProvider/Category.php
@@ -8,8 +8,12 @@ declare (strict_types = 1);
 namespace Magefan\BlogGraphQl\Model\Resolver\DataProvider;
 
 use Magefan\Blog\Api\CategoryRepositoryInterface;
+use Magento\Framework\App\Area;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\State;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\View\DesignInterface;
+use Magento\Framework\View\Design\Theme\ThemeProviderInterface;
 use Magento\Widget\Model\Template\FilterEmulate;
 
 /**
@@ -34,18 +38,43 @@ class Category
     protected $state;
 
     /**
+     * @var \Magento\Framework\View\DesignInterface
+     */
+    private $design;
+
+    /**
+     * @var \Magento\Framework\View\Design\Theme\ThemeProviderInterface
+     */
+    private $themeProvider;
+
+    /**
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
      * Category constructor.
      * @param CategoryRepositoryInterface $categoryRepository
-     * @param FilterEmulate $widgetFilter
+     * @param FilterEmulate               $widgetFilter
+     * @param State                       $state
+     * @param DesignInterface             $design
+     * @param ThemeProviderInterface      $themeProvider
+     * @param ScopeConfigInterface        $scopeConfig
      */
     public function __construct(
         CategoryRepositoryInterface $categoryRepository,
         FilterEmulate $widgetFilter,
-        State $state
+        State $state,
+        DesignInterface $design,
+        ThemeProviderInterface $themeProvider,
+        ScopeConfigInterface $scopeConfig
     ) {
         $this->categoryRepository = $categoryRepository;
         $this->widgetFilter       = $widgetFilter;
         $this->state              = $state;
+        $this->design             = $design;
+        $this->themeProvider      = $themeProvider;
+        $this->scopeConfig        = $scopeConfig;
     }
 
     /**
@@ -64,8 +93,15 @@ class Category
 
         $data = [];
         $this->state->emulateAreaCode(
-            'frontend',
+            Area::AREA_FRONTEND,
             function () use ($category, &$data) {
+                $themeId = $this->scopeConfig->getValue(
+                    'design/theme/theme_id',
+                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                );
+                $theme = $this->themeProvider->getThemeById($themeId);
+                $this->design->setDesignTheme($theme, Area::AREA_FRONTEND);
+
                 $data = $category->getDynamicData();
 
                 return $data;

--- a/Model/Resolver/DataProvider/Category.php
+++ b/Model/Resolver/DataProvider/Category.php
@@ -3,11 +3,12 @@
  * Copyright © Magefan (support@magefan.com). All rights reserved.
  * Please visit Magefan.com for license details (https://magefan.com/end-user-license-agreement).
  */
-declare(strict_types=1);
+declare (strict_types = 1);
 
 namespace Magefan\BlogGraphQl\Model\Resolver\DataProvider;
 
 use Magefan\Blog\Api\CategoryRepositoryInterface;
+use Magento\Framework\App\State;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Widget\Model\Template\FilterEmulate;
 
@@ -34,10 +35,12 @@ class Category
      */
     public function __construct(
         CategoryRepositoryInterface $categoryRepository,
-        FilterEmulate $widgetFilter
+        FilterEmulate $widgetFilter,
+        State $state
     ) {
         $this->categoryRepository = $categoryRepository;
-        $this->widgetFilter = $widgetFilter;
+        $this->widgetFilter       = $widgetFilter;
+        $this->state              = $state;
     }
 
     /**
@@ -54,6 +57,16 @@ class Category
             throw new NoSuchEntityException();
         }
 
-        return $category->getDynamicData();
+        $data = [];
+        $this->state->emulateAreaCode(
+            'frontend',
+            function () use ($category, &$data) {
+                $data = $category->getDynamicData();
+
+                return $data;
+            }
+        );
+
+        return $data;
     }
 }

--- a/Model/Resolver/DataProvider/Post.php
+++ b/Model/Resolver/DataProvider/Post.php
@@ -3,11 +3,12 @@
  * Copyright © Magefan (support@magefan.com). All rights reserved.
  * Please visit Magefan.com for license details (https://magefan.com/end-user-license-agreement).
  */
-declare(strict_types=1);
+declare (strict_types = 1);
 
 namespace Magefan\BlogGraphQl\Model\Resolver\DataProvider;
 
 use Magefan\Blog\Api\PostRepositoryInterface;
+use Magento\Framework\App\State;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Widget\Model\Template\FilterEmulate;
 
@@ -28,16 +29,23 @@ class Post
     private $postRepository;
 
     /**
+     * @var Magento\Framework\App\State
+     */
+    protected $state;
+
+    /**
      * Post constructor.
      * @param PostRepositoryInterface $postRepository
      * @param FilterEmulate $widgetFilter
      */
     public function __construct(
         PostRepositoryInterface $postRepository,
-        FilterEmulate $widgetFilter
+        FilterEmulate $widgetFilter,
+        State $state
     ) {
         $this->postRepository = $postRepository;
-        $this->widgetFilter = $widgetFilter;
+        $this->widgetFilter   = $widgetFilter;
+        $this->state          = $state;
     }
 
     /**
@@ -55,6 +63,16 @@ class Post
             throw new NoSuchEntityException();
         }
 
-        return $post->getDynamicData($fields);
+        $data = [];
+        $this->state->emulateAreaCode(
+            'frontend',
+            function () use ($post, $fields, &$data) {
+                $data = $post->getDynamicData($fields);
+
+                return $data;
+            }
+        );
+
+        return $data;
     }
 }

--- a/Model/Resolver/DataProvider/Post.php
+++ b/Model/Resolver/DataProvider/Post.php
@@ -8,8 +8,12 @@ declare (strict_types = 1);
 namespace Magefan\BlogGraphQl\Model\Resolver\DataProvider;
 
 use Magefan\Blog\Api\PostRepositoryInterface;
+use Magento\Framework\App\Area;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\State;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\View\DesignInterface;
+use Magento\Framework\View\Design\Theme\ThemeProviderInterface;
 use Magento\Widget\Model\Template\FilterEmulate;
 
 /**
@@ -34,18 +38,43 @@ class Post
     protected $state;
 
     /**
+     * @var \Magento\Framework\View\DesignInterface
+     */
+    private $design;
+
+    /**
+     * @var \Magento\Framework\View\Design\Theme\ThemeProviderInterface
+     */
+    private $themeProvider;
+
+    /**
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
      * Post constructor.
      * @param PostRepositoryInterface $postRepository
-     * @param FilterEmulate $widgetFilter
+     * @param FilterEmulate           $widgetFilter
+     * @param State                   $state
+     * @param DesignInterface         $design
+     * @param ThemeProviderInterface  $themeProvider
+     * @param ScopeConfigInterface    $scopeConfig
      */
     public function __construct(
         PostRepositoryInterface $postRepository,
         FilterEmulate $widgetFilter,
-        State $state
+        State $state,
+        DesignInterface $design,
+        ThemeProviderInterface $themeProvider,
+        ScopeConfigInterface $scopeConfig
     ) {
         $this->postRepository = $postRepository;
         $this->widgetFilter   = $widgetFilter;
         $this->state          = $state;
+        $this->design         = $design;
+        $this->themeProvider  = $themeProvider;
+        $this->scopeConfig    = $scopeConfig;
     }
 
     /**
@@ -65,8 +94,15 @@ class Post
 
         $data = [];
         $this->state->emulateAreaCode(
-            'frontend',
+            Area::AREA_FRONTEND,
             function () use ($post, $fields, &$data) {
+                $themeId = $this->scopeConfig->getValue(
+                    'design/theme/theme_id',
+                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                );
+                $theme = $this->themeProvider->getThemeById($themeId);
+                $this->design->setDesignTheme($theme, Area::AREA_FRONTEND);
+
                 $data = $post->getDynamicData($fields);
 
                 return $data;

--- a/Model/Resolver/DataProvider/Tag.php
+++ b/Model/Resolver/DataProvider/Tag.php
@@ -29,6 +29,11 @@ class Tag
     private $tagRepository;
 
     /**
+     * @var Magento\Framework\App\State
+     */
+    protected $state;
+
+    /**
      * Tag constructor.
      * @param TagRepositoryInterface $tagRepository
      * @param FilterEmulate $widgetFilter

--- a/Model/Resolver/DataProvider/Tag.php
+++ b/Model/Resolver/DataProvider/Tag.php
@@ -8,8 +8,12 @@ declare (strict_types = 1);
 namespace Magefan\BlogGraphQl\Model\Resolver\DataProvider;
 
 use Magefan\Blog\Api\TagRepositoryInterface;
+use Magento\Framework\App\Area;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\State;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\View\DesignInterface;
+use Magento\Framework\View\Design\Theme\ThemeProviderInterface;
 use Magento\Widget\Model\Template\FilterEmulate;
 
 /**
@@ -34,18 +38,43 @@ class Tag
     protected $state;
 
     /**
+     * @var \Magento\Framework\View\DesignInterface
+     */
+    private $design;
+
+    /**
+     * @var \Magento\Framework\View\Design\Theme\ThemeProviderInterface
+     */
+    private $themeProvider;
+
+    /**
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
      * Tag constructor.
      * @param TagRepositoryInterface $tagRepository
-     * @param FilterEmulate $widgetFilter
+     * @param FilterEmulate          $widgetFilter
+     * @param State                  $state
+     * @param DesignInterface        $design
+     * @param ThemeProviderInterface $themeProvider
+     * @param ScopeConfigInterface   $scopeConfig
      */
     public function __construct(
         TagRepositoryInterface $tagRepository,
         FilterEmulate $widgetFilter,
-        State $state
+        State $state,
+        DesignInterface $design,
+        ThemeProviderInterface $themeProvider,
+        ScopeConfigInterface $scopeConfig
     ) {
         $this->tagRepository = $tagRepository;
         $this->widgetFilter  = $widgetFilter;
         $this->state         = $state;
+        $this->design        = $design;
+        $this->themeProvider = $themeProvider;
+        $this->scopeConfig   = $scopeConfig;
     }
 
     /**
@@ -64,8 +93,15 @@ class Tag
 
         $data = [];
         $this->state->emulateAreaCode(
-            'frontend',
+            Area::AREA_FRONTEND,
             function () use ($tag, &$data) {
+                $themeId = $this->scopeConfig->getValue(
+                    'design/theme/theme_id',
+                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                );
+                $theme = $this->themeProvider->getThemeById($themeId);
+                $this->design->setDesignTheme($theme, Area::AREA_FRONTEND);
+
                 $data = $tag->getDynamicData();
 
                 return $data;

--- a/Model/Resolver/DataProvider/Tag.php
+++ b/Model/Resolver/DataProvider/Tag.php
@@ -3,11 +3,12 @@
  * Copyright © Magefan (support@magefan.com). All rights reserved.
  * Please visit Magefan.com for license details (https://magefan.com/end-user-license-agreement).
  */
-declare(strict_types=1);
+declare (strict_types = 1);
 
 namespace Magefan\BlogGraphQl\Model\Resolver\DataProvider;
 
 use Magefan\Blog\Api\TagRepositoryInterface;
+use Magento\Framework\App\State;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Widget\Model\Template\FilterEmulate;
 
@@ -34,10 +35,12 @@ class Tag
      */
     public function __construct(
         TagRepositoryInterface $tagRepository,
-        FilterEmulate $widgetFilter
+        FilterEmulate $widgetFilter,
+        State $state
     ) {
         $this->tagRepository = $tagRepository;
-        $this->widgetFilter = $widgetFilter;
+        $this->widgetFilter  = $widgetFilter;
+        $this->state         = $state;
     }
 
     /**
@@ -54,6 +57,16 @@ class Tag
             throw new NoSuchEntityException();
         }
 
-        return $tag->getDynamicData();
+        $data = [];
+        $this->state->emulateAreaCode(
+            'frontend',
+            function () use ($tag, &$data) {
+                $data = $tag->getDynamicData();
+
+                return $data;
+            }
+        );
+
+        return $data;
     }
 }


### PR DESCRIPTION
When a widget is inserted in the blog content, for example: Products, we will receive an "Invalid template file" error.

"version": "2.0.4"
Query: 
```
query blogPost {
  blogPost(id: "13") {
    filtered_content
  }
}
```
Result:
```
{
  "data": {
    "blogPost": {
      "filtered_content": "Error filtering template: Invalid template file: 'Magento_CatalogWidget::product/widget/content/grid.phtml' in module: 'Magento_CatalogWidget' block's name: 'product\\productslist_0'"
    }
  }
}
```