### PR TITLE
Add missing, required, `xsi:type` definition to argument node

### DIFF
--- a/etc/graphql/di.xml
+++ b/etc/graphql/di.xml
@@ -8,7 +8,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="Magento\StoreGraphQl\Model\Resolver\Store\StoreConfigDataProvider">
         <arguments>
-            <argument name="extendedConfigData">
+            <argument name="extendedConfigData" xsi:type="array">
                 <item name="mfblog_design_publication_date" xsi:type="string">mfblog/design/publication_date</item>
                 <item name="mfblog_design_format_date" xsi:type="string">mfblog/design/format_date</item>
                 <item name="mfblog_index_page_title" xsi:type="string">mfblog/index_page/title</item>


### PR DESCRIPTION
Adds the missing `xsi:type` argument for the `<argument>` node. Without the `xsi:type` present, errors are shown during DOM validation:

<details>
<summary>Example error</summary>

```
In Filesystem.php line 168:
                                                                                                              
  Invalid Document                                                                                            
  Element 'argument': The type definition is abstract.                                                        
  Line: 11                                                                                                    
                                                                                                              
  Internal error: xmlSchemaXPathProcessHistory, The state object to be removed is not the first in the list.  
  Line: 10                                                                                                    
                                                                                                              
  Internal error: xmlSchemaValidateChildElem, calling xmlRegExecPushString2().                                
  Line: 104                                                                                                   
                                                                                                              
  Internal error: xmlSchemaValidateElem, calling xmlSchemaStreamValidateChildElement().                       
  Line: 104                                                                                                   
                                                                                                              
  Internal error: xmlSchemaDocWalk, calling xmlSchemaValidateElem().                                          
  Line: 104                                                                                                                            
```
</details>