### PR TITLE
EntityUrl id - Wrong type

### DIFF
--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -77,11 +77,6 @@ enum UrlRewriteEntityTypeEnum {
     MF_BLOG_SEARCH
 }
 
-type EntityUrl @doc(description: "") {
-    id: String @doc(description: "")
-
-}
-
 type blogPostsOutput implements RoutableInterface {
     total_count: Int @doc(description: "")
     total_pages: Int @doc(description: "")


### PR DESCRIPTION
The property `id` of the `EntityUrl` is explicitly designated as an Int type. This specification is crucial for maintaining consistency and preventing complications in projects that rely on this value. When individuals attempt to update this property with a different data type, it can lead to unforeseen issues.

https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/UrlRewriteGraphQl/etc/schema.graphqls#L10